### PR TITLE
DO-2718 Add iris-router chart

### DIFF
--- a/iris-router/.helmignore
+++ b/iris-router/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/iris-router/Chart.yaml
+++ b/iris-router/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: iris-router
+description: A Helm chart for iris-router on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v3.0.10"

--- a/iris-router/templates/NOTES.txt
+++ b/iris-router/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "iris-router.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "iris-router.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "iris-router.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "iris-router.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/iris-router/templates/_helpers.tpl
+++ b/iris-router/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "iris-router.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "iris-router.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "iris-router.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "iris-router.labels" -}}
+helm.sh/chart: {{ include "iris-router.chart" . }}
+{{ include "iris-router.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "iris-router.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "iris-router.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "iris-router.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "iris-router.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/iris-router/templates/deployment.yaml
+++ b/iris-router/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "iris-router.fullname" . }}
+  labels:
+    {{- include "iris-router.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "iris-router.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "iris-router.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "iris-router.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+          - secretRef:
+              name: {{ include "iris-router.fullname" . }}
+          {{- if or .Values.extraEnv .Values.rabbitmq.existingSecret }}
+          env:
+          {{- if .Values.rabbitmq.existingSecret }}
+            - name: RABBIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rabbitmq.existingSecret }}
+                  key: {{ .Values.rabbitmq.existingSecretPasswordKey }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/iris-router/templates/hpa.yaml
+++ b/iris-router/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "iris-router.fullname" . }}
+  labels:
+    {{- include "iris-router.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "iris-router.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/iris-router/templates/ingress.yaml
+++ b/iris-router/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "iris-router.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "iris-router.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/iris-router/templates/secret.yaml
+++ b/iris-router/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "iris-router.fullname" . }}
+  labels:
+{{ include "iris-router.labels" . | nindent 4 }}
+data:
+  RABBIT_USERNAME: {{ .Values.rabbitmq.username | b64enc }}
+  RABBIT_HOST: {{ .Values.rabbitmq.host | b64enc }}
+  RABBIT_PROTOCOL: {{ .Values.rabbitmq.protocol | default "amqps" | b64enc }}
+  RABBIT_PORT: {{ .Values.rabbitmq.port | default 5672 | toString | b64enc }}
+  {{- if and .Values.rabbitmq.password (not .Values.rabbitmq.existingSecret) }}
+  RABBIT_PASSWORD: {{ .Values.rabbitmq.password | b64enc }}
+  {{- end }}

--- a/iris-router/templates/service.yaml
+++ b/iris-router/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iris-router.fullname" . }}
+  labels:
+    {{- include "iris-router.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "iris-router.selectorLabels" . | nindent 4 }}

--- a/iris-router/templates/serviceaccount.yaml
+++ b/iris-router/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "iris-router.serviceAccountName" . }}
+  labels:
+    {{- include "iris-router.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/iris-router/templates/tests/test-connection.yaml
+++ b/iris-router/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "iris-router.fullname" . }}-test-connection"
+  labels:
+    {{- include "iris-router.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "iris-router.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/iris-router/values.yaml
+++ b/iris-router/values.yaml
@@ -1,0 +1,133 @@
+# Default values for iris-router.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/iris-events/router-native
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+#nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+rabbitmq:
+  host: rabbitmq.local
+  port: 5672
+  protocol: amqps
+  username: router
+  #password: router
+
+  ## The name of an existing secret with rabbitmq credentials, it will take precedence over rabbitmq.password
+  # existingSecret: rabbitmq-secrets
+
+  ## Password key to be retrieved from existing secret
+  # existingSecretPasswordKey: rabbitmq-password
+
+extraEnv:
+  []
+  # - name: MY_SPECIAL_ENV
+  #   value: verySpecialValue
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: iris-router.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: iris-router-tls
+  #    hosts:
+  #      - iris-router.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /q/health/live
+    port: 8080
+readinessProbe:
+  httpGet:
+    path: /q/health/ready
+    port: 8080
+startupProbe:
+  httpGet:
+    path: /q/health/started
+    port: 8080
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This pull request introduces a Helm chart for the `iris-router` application. The changes are primarily focused on setting up the necessary Kubernetes resources, such as Deployments, Services, Ingress, and HorizontalPodAutoscaler, among others, to deploy and manage the `iris-router` application on a Kubernetes cluster. 

Setup and Configuration:

* [`iris-router/Chart.yaml`](diffhunk://#diff-2dddcea69bf0a5bf09d2dc21c0fe83a04c43812969a8e25f5d42c129412f5075R1-R24): This file defines the basic information about the Helm chart, such as the chart's version, the application's version, and the type of the chart.

Deployment and Management:

* [`iris-router/templates/deployment.yaml`](diffhunk://#diff-f709e76ef63e0999aa36738fce61f15f243b4dfc932399b951a8012875dd42b1R1-R86): This file defines a Deployment for the `iris-router` application. It specifies the necessary details, such as the container image to use, the container port to expose, and the environment variables to set.
* [`iris-router/templates/service.yaml`](diffhunk://#diff-bd516d1851ffb47cee93bd640fd7be340146025987931a450d6b202b4c8858f5R1-R15): This file defines a Service for the `iris-router` application. It specifies the type of the service and the port to expose.
* [`iris-router/templates/hpa.yaml`](diffhunk://#diff-35f83d069c1b450d5892af4f65a20b35a323f8901f98613c5281eac394c2efceR1-R32): This file defines a HorizontalPodAutoscaler for the `iris-router` application. It specifies the minimum and maximum number of replicas and the target CPU and memory utilization percentages.
* [`iris-router/templates/ingress.yaml`](diffhunk://#diff-f63e77dc2b2ee5b609129efcc1117fc6caceea97f12d0d1ac8eb48f9655ce4c5R1-R61): This file defines an Ingress for the `iris-router` application. It specifies the host and path to route traffic to the `iris-router` service.

Auxiliary Configurations:

* [`iris-router/.helmignore`](diffhunk://#diff-26fc796403706e46b7ef101def1475cf9ef4d0f2eb8376796374961f2358058dR1-R23): This file specifies the patterns to ignore when building the Helm chart package.
* [`iris-router/templates/NOTES.txt`](diffhunk://#diff-d7ca75edfcc66306239461bfb131bf34dc3726ee3f686f5dfde735366069eb2dR1-R22): This file provides instructions on how to get the application URL based on the type of service used.
* [`iris-router/templates/_helpers.tpl`](diffhunk://#diff-c5c2fd28a5e2d182e1c26d2e4137dcadd7a3dfa23880f0f630bd12a9772a3116R1-R62): This file defines helper templates that can be reused in other templates.
* [`iris-router/templates/secret.yaml`](diffhunk://#diff-598f8b9df11f68c8c6367054cd2c4fd0c830d653e19e7de0bff1c96caa71fca2R1-R14): This file defines a Secret that holds the RabbitMQ credentials.
* [`iris-router/templates/serviceaccount.yaml`](diffhunk://#diff-cea504f70b70b3f6012fe20a1dfb8e33f7c3da303e806b45abfc5043842ae14aR1-R13): This file defines a ServiceAccount for the `iris-router` application.
* [`iris-router/templates/tests/test-connection.yaml`](diffhunk://#diff-f506c2557e08f550df352728442d14df44f85e54710a9b6daff98ba1a8f7d22dR1-R15): This file defines a test Pod that verifies the connection to the `iris-router` service.
* [`iris-router/values.yaml`](diffhunk://#diff-da24b7abf37463b71012c51450820a3594f8948e2073321a0380467387df6872R1-R133): This file provides default values for the Helm chart. It includes configurations for the image, service, ingress, resources, and autoscaling, among others.