### PR TITLE
DO-2718 Add envFrom option for existing configmap or secrets

### DIFF
--- a/iris-manager/Chart.yaml
+++ b/iris-manager/Chart.yaml
@@ -15,11 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v2.0.1"
-

--- a/iris-manager/templates/deployment.yaml
+++ b/iris-manager/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           envFrom:
           - secretRef:
               name: {{ include "iris-manager.fullname" . }}
+          {{- if .Values.envFrom }}
+            {{- toYaml .Values.envFrom | nindent 10 }}
+          {{- end }}
           {{- if or .Values.extraEnv .Values.rabbitmq.existingSecret }}
           env:
           {{- if .Values.rabbitmq.existingSecret }}

--- a/iris-manager/values.yaml
+++ b/iris-manager/values.yaml
@@ -59,6 +59,14 @@ extraEnv:
   # - name: MY_SPECIAL_ENV
   #   value: verySpecialValue
 
+# Load env variables from existing configMapRef or secretRef
+envFrom:
+  []
+  # - configMapRef:
+  #     name: shared-config
+  # - secretRef:
+  #     name: existing-secret
+
 service:
   type: ClusterIP
   port: 8080

--- a/iris-router/Chart.yaml
+++ b/iris-router/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/iris-router/templates/deployment.yaml
+++ b/iris-router/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           envFrom:
           - secretRef:
               name: {{ include "iris-router.fullname" . }}
+          {{- if .Values.envFrom }}
+            {{- toYaml .Values.envFrom | nindent 10 }}
+          {{- end }}
           {{- if or .Values.extraEnv .Values.rabbitmq.existingSecret }}
           env:
           {{- if .Values.rabbitmq.existingSecret }}

--- a/iris-router/values.yaml
+++ b/iris-router/values.yaml
@@ -59,6 +59,14 @@ extraEnv:
   # - name: MY_SPECIAL_ENV
   #   value: verySpecialValue
 
+# Load env variables from existing configMapRef or secretRef
+envFrom:
+  []
+  # - configMapRef:
+  #     name: shared-config
+  # - secretRef:
+  #     name: existing-secret
+
 service:
   type: ClusterIP
   port: 8080

--- a/iris-subscription/Chart.yaml
+++ b/iris-subscription/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/iris-subscription/templates/deployment.yaml
+++ b/iris-subscription/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           envFrom:
           - secretRef:
               name: {{ include "iris-subscription.fullname" . }}
+          {{- if .Values.envFrom }}
+            {{- toYaml .Values.envFrom | nindent 10 }}
+          {{- end }}
           {{- if or .Values.extraEnv .Values.rabbitmq.existingSecret }}
           env:
           {{- if .Values.rabbitmq.existingSecret }}

--- a/iris-subscription/values.yaml
+++ b/iris-subscription/values.yaml
@@ -63,6 +63,14 @@ extraEnv:
   # - name: MY_SPECIAL_ENV
   #   value: verySpecialValue
 
+# Load env variables from existing configMapRef or secretRef
+envFrom:
+  []
+  # - configMapRef:
+  #     name: shared-config
+  # - secretRef:
+  #     name: existing-secret
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
This pull request includes changes across multiple files in the `iris-manager`, `iris-router`, and `iris-subscription` directories. The changes primarily involve version updates in the `Chart.yaml` files and the addition of environment variable loading from existing `configMapRef` or `secretRef` in the `values.yaml` and `deployment.yaml` files.

Version updates:

* [`iris-manager/Chart.yaml`](diffhunk://#diff-7ff65ae19862a6e722327b8b67e582db4e5494e5c09bd47a61c9ae0b7b7ffdebL18-L25): The chart version was updated from `0.1.0` to `0.0.2`.
* [`iris-router/Chart.yaml`](diffhunk://#diff-2dddcea69bf0a5bf09d2dc21c0fe83a04c43812969a8e25f5d42c129412f5075L18-R18): The chart version was updated from `0.1.0` to `0.0.2`.
* [`iris-subscription/Chart.yaml`](diffhunk://#diff-06ba140dbb491bb066cd9d588a2e662fb51683a1e44d5a909d8d0a9ec3ff39afL18-R18): The chart version was updated from `0.1.0` to `0.0.2`.

Environment variable loading:

* `iris-manager/values.yaml` and `iris-manager/templates/deployment.yaml`: Added the ability to load environment variables from an existing `configMapRef` or `secretRef`. [[1]](diffhunk://#diff-1b2d2fbb3e79d70ce2dc86a95e9dd88e603fe4c7870aa8d628843e66b347b51bR62-R69) [[2]](diffhunk://#diff-d1cfa6551ce3b4f63e479564f1074a20f444f1a3631434199a4daab39f2b4d9cR42-R44)
* `iris-router/values.yaml` and `iris-router/templates/deployment.yaml`: Added the ability to load environment variables from an existing `configMapRef` or `secretRef`. [[1]](diffhunk://#diff-da24b7abf37463b71012c51450820a3594f8948e2073321a0380467387df6872R62-R69) [[2]](diffhunk://#diff-f709e76ef63e0999aa36738fce61f15f243b4dfc932399b951a8012875dd42b1R42-R44)
* `iris-subscription/values.yaml` and `iris-subscription/templates/deployment.yaml`: Added the ability to load environment variables from an existing `configMapRef` or `secretRef`. [[1]](diffhunk://#diff-f1e7ab361ef1df8b9846bbfd69794be721e318fe4be630bb6fcf39210684afedR66-R73) [[2]](diffhunk://#diff-a325b2676419994d07398dbabd066873811df85ea8b6042cf17b4eacc6933dd7R42-R44)