### PR TITLE
Bump Iris Router and chart version

### DIFF
--- a/manager/Chart.yaml
+++ b/manager/Chart.yaml
@@ -15,11 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v2.0.1"
-

--- a/router/Chart.yaml
+++ b/router/Chart.yaml
@@ -15,11 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.1.5"
-
+appVersion: "v3.1.7"

--- a/subscription/Chart.yaml
+++ b/subscription/Chart.yaml
@@ -15,11 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v3.0.1"
-


### PR DESCRIPTION
This pull request includes version updates for the chart and application versions in three different Helm chart files. The changes ensure that the charts follow Semantic Versioning and reflect the correct application versions.

Version updates:

* [`manager/Chart.yaml`](diffhunk://#diff-333043bf8c2fd43c8a1b24662d954783c43870d6cc42ee4aa2e5ef16a1fb0bc1L18-L25): Updated chart version to `0.0.9`
* [`router/Chart.yaml`](diffhunk://#diff-1bfabfafa93cfbbad37a4d79257d56bbe684896eb10b6575e313172a65c04cf6L18-R24): Updated chart version to `0.0.9` and application version to `v3.1.7`
* [`subscription/Chart.yaml`](diffhunk://#diff-b11db35806e195d3459ac5b464f842bb8a4ce363793b6c62ae606d0bcb00ab6eL18-L25): Updated chart version to `0.0.9`